### PR TITLE
Add OpenAPI validation test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openapi-spec-validator==0.6.0
+pytest==8.1.1

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,10 @@
+import json
+from pathlib import Path
+from openapi_spec_validator import validate_spec
+
+def test_openapi_valid():
+    spec_path = Path(__file__).resolve().parents[1] / "basics" / "openapi.json"
+    with spec_path.open() as f:
+        spec = json.load(f)
+    # validate_spec will raise an exception if the spec is invalid
+    validate_spec(spec)


### PR DESCRIPTION
## Summary
- add `openapi-spec-validator` and `pytest` to project dependencies
- create regression test ensuring `basics/openapi.json` validates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d9385ef708327ad54e4b54ce624dd